### PR TITLE
Additional improvements

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -171,9 +171,6 @@ impl App {
     }
 
     fn next_action(&mut self) -> io::Result<()> {
-        if self.finished && *self.action_status.lock().unwrap() == ActionStatus::Forced {
-            return Ok(());
-        }
         if *self.action_status.lock().unwrap() == ActionStatus::Running {
             *self.action_status.lock().unwrap() = ActionStatus::Forced;
             return Ok(());

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use anyhow::{Context, Result};
-use core::fmt;
 use jsonschema;
 use ratatui::style::{Color, Modifier, Style};
 use serde::{Deserialize, Serialize};
@@ -60,7 +59,7 @@ impl Into<Style> for StyleConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct Stage {
     pub name: String,
     pub actions: Vec<Action>,
@@ -73,21 +72,20 @@ pub enum CommandType {
     Multiple(Vec<String>),
 }
 
-impl fmt::Debug for CommandType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl CommandType {
+    pub fn get_command(&self) -> String {
         match self {
             Self::Single(ref cmd) => {
-                write!(f, "{}", cmd)
+                cmd.clone()
             }
             Self::Multiple(ref cmds) => {
-                let out: String = cmds.into_iter().map(|cmd| format!("{}; ", cmd)).collect();
-                write!(f, "{}", out)
+                cmds.join(" && ")
             }
         }
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum Action {
     Message {
@@ -127,7 +125,7 @@ pub struct LoopConfig {
     pub delay: u64,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Default, Deserialize, Serialize)]
 pub struct Config {
     pub stages: Vec<Stage>,
 }


### PR DESCRIPTION
1. Added logic to interrupt the command
2. Improved user notifications, especially in case of an interruped command.
3. Improved handling of chained commands.
Old behavior:
```
[admin@localhost:2222]$ mkdir my_dir; cd my_dir; touch my_file.txt; pwd; ls -l;
/home/admin
total 4
drwxr-xr-x. 2 admin admin 4096 Mar 18 09:28 my_dir
-rw-r--r--. 1 admin admin    0 Mar 18 09:28 my_file.txt
```
New behavior:
```
[admin@localhost:2222]$ mkdir my_dir && cd my_dir && touch my_file.txt && pwd && ls -l;
/home/admin/my_dir
total 0
-rw-r--r--. 1 admin admin 0 Mar 18 14:50 my_file.txt
```
4. Some code refactoring and simplification.