### PR TITLE
Enhanced environment variables' support & improved error handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ and styled terminal output.
   - Local or remote (via `ssh`) execution
   - Run as regular or privileged user
   - Support list of commands
+- Support environment variables
+  - Remote connection password
+  - Remote sudo password
 - Loops with configurable delay
 - Hide commands' output (`stdout` and/or `stderr`) for silent execution
 - YAML-based, human-friendly configuration
@@ -71,20 +74,37 @@ stages:
           color: "yellow"
           italic: true
 
+      # Multiple commands support.
       - type: command
         command:
           - restart-service.sh
-          - echo 'Service restarted'
+          - echo 'Service restarted!'
         hide_stdout: true
         hide_stderr: false
+        remote:
+          user: admin
+          host: server.com
+          port: 22
+          password: admin1234
         sudo:
           user: root
-          password: admin1234
+          password: root1234
+
+      # Environment variables support (security).
+      - type: command
+        command: config_collector.sh 1.1.1.1
         remote:
-          user: user
+          user: admin
           host: server.com
           port: 22
           password: $env:REMOTE_PASSWORD
+        sudo:
+          user: root
+          password: $env:REMOTE_SUDO_PASSWORD
+
+      # Local execution in a loop.
+      - type: command
+        command: mine-bitcoin.sh
         loop:
           times: 3
           delay: 2000
@@ -111,4 +131,4 @@ includes a modern user interface to show the demos.
 
 # Contribute
 
-PRs welcome! Feel free to open issues for new features.
+PRs are welcome! Feel free to open issues for new features.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ and styled terminal output.
   - Run as regular or privileged user
   - Support list of commands
 - Support environment variables
+  - Inside commands
   - Remote connection host
   - Remote connection user
   - Remote connection password
@@ -95,7 +96,7 @@ stages:
 
       # Environment variables support (security & usability).
       - type: command
-        command: config_collector.sh 1.1.1.1
+        command: config_collector.sh $env:GRAFANA_IP
         remote:
           user: $env:REMOTE_USER
           host: $env:REMOTE_HOST

--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ and styled terminal output.
   - Run as regular or privileged user
   - Support list of commands
 - Support environment variables
+  - Remote connection host
+  - Remote connection user
   - Remote connection password
+  - Remote sudo user
   - Remote sudo password
 - Loops with configurable delay
 - Hide commands' output (`stdout` and/or `stderr`) for silent execution
@@ -90,16 +93,16 @@ stages:
           user: root
           password: root1234
 
-      # Environment variables support (security).
+      # Environment variables support (security & usability).
       - type: command
         command: config_collector.sh 1.1.1.1
         remote:
-          user: admin
-          host: server.com
+          user: $env:REMOTE_USER
+          host: $env:REMOTE_HOST
           port: 22
           password: $env:REMOTE_PASSWORD
         sudo:
-          user: root
+          user: $env:REMOTE_SUDO_USER
           password: $env:REMOTE_SUDO_PASSWORD
 
       # Local execution in a loop.

--- a/autopilot.schema.json
+++ b/autopilot.schema.json
@@ -51,7 +51,7 @@
                   "speed": {
                     "type": "integer",
                     "minimum": 0,
-                    "description": "Typing speed in milliseconds per character (default 50)"
+                    "description": "Typing speed in milliseconds per character (default '50')"
                   },
                   "command": {
                     "type": ["string", "array"],
@@ -94,7 +94,7 @@
                         "type": "integer",
                         "minimum": 1,
                         "maximum": 65535,
-                        "description": "Remote SSH port (default 22)"
+                        "description": "Remote SSH port (default '22')"
                       },
                       "user": {
                         "type": "string",

--- a/autopilot.schema.json
+++ b/autopilot.schema.json
@@ -66,7 +66,7 @@
                     "properties": {
                       "user": {
                         "type": "string",
-                        "description": "Privileged user (default 'root')"
+                        "description": "Privileged user (default 'root'). Can use '$env:' prefix to mark value as environment variable"
                       },
                       "password": {
                         "type": "string",
@@ -88,7 +88,7 @@
                     "properties": {
                       "host": {
                         "type": "string",
-                        "description": "Remote SSH host"
+                        "description": "Remote SSH host. Can use '$env:' prefix to mark value as environment variable"
                       },
                       "port": {
                         "type": "integer",
@@ -98,7 +98,7 @@
                       },
                       "user": {
                         "type": "string",
-                        "description": "Remote SSH user"
+                        "description": "Remote SSH user. Can use '$env:' prefix to mark value as environment variable"
                       },
                       "password": {
                         "type": "string",

--- a/docs/config.md
+++ b/docs/config.md
@@ -118,18 +118,18 @@ SPDX-License-Identifier: GPL-3.0-or-later
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                  | Pattern | Type                      | Deprecated | Definition | Title/Description                                       |
-|-----------------------------------------------------------|---------|---------------------------|------------|------------|---------------------------------------------------------|
-| + [type](#stages_items_actions_items_type )               | No      | enum (of string)          | No         | -          | Action type: message or command                         |
-| - [text](#stages_items_actions_items_text )               | No      | string                    | No         | -          | Message text (required for message actions)             |
-| - [style](#stages_items_actions_items_style )             | No      | object                    | No         | -          | -                                                       |
-| - [speed](#stages_items_actions_items_speed )             | No      | integer                   | No         | -          | Typing speed in milliseconds per character (default 50) |
-| - [command](#stages_items_actions_items_command )         | No      | string or array of string | No         | -          | Shell command to execute (required for command actions) |
-| - [sudo](#stages_items_actions_items_sudo )               | No      | object                    | No         | -          | Run command with elevated privileges                    |
-| - [hide_stdout](#stages_items_actions_items_hide_stdout ) | No      | boolean                   | No         | -          | Hide command's stdout (default false)                   |
-| - [hide_stderr](#stages_items_actions_items_hide_stderr ) | No      | boolean                   | No         | -          | Hide command's stderr (default false)                   |
-| - [remote](#stages_items_actions_items_remote )           | No      | object                    | No         | -          | -                                                       |
-| - [loop](#stages_items_actions_items_loop )               | No      | object                    | No         | -          | -                                                       |
+| Property                                                  | Pattern | Type                      | Deprecated | Definition | Title/Description                                         |
+|-----------------------------------------------------------|---------|---------------------------|------------|------------|-----------------------------------------------------------|
+| + [type](#stages_items_actions_items_type )               | No      | enum (of string)          | No         | -          | Action type: message or command                           |
+| - [text](#stages_items_actions_items_text )               | No      | string                    | No         | -          | Message text (required for message actions)               |
+| - [style](#stages_items_actions_items_style )             | No      | object                    | No         | -          | -                                                         |
+| - [speed](#stages_items_actions_items_speed )             | No      | integer                   | No         | -          | Typing speed in milliseconds per character (default `50`) |
+| - [command](#stages_items_actions_items_command )         | No      | string or array of string | No         | -          | Shell command to execute (required for command actions)   |
+| - [sudo](#stages_items_actions_items_sudo )               | No      | object                    | No         | -          | Run command with elevated privileges                      |
+| - [hide_stdout](#stages_items_actions_items_hide_stdout ) | No      | boolean                   | No         | -          | Hide command's stdout (default false)                     |
+| - [hide_stderr](#stages_items_actions_items_hide_stderr ) | No      | boolean                   | No         | -          | Hide command's stderr (default false)                     |
+| - [remote](#stages_items_actions_items_remote )           | No      | object                    | No         | -          | -                                                         |
+| - [loop](#stages_items_actions_items_loop )               | No      | object                    | No         | -          | -                                                         |
 
 | Any of(Option)                                 |
 |------------------------------------------------|
@@ -237,7 +237,7 @@ Must be one of:
 | **Type**     | `integer` |
 | **Required** | No        |
 
-**Description:** Typing speed in milliseconds per character (default 50)
+**Description:** Typing speed in milliseconds per character (default `50`)
 
 | Restrictions |        |
 |--------------|--------|
@@ -264,7 +264,7 @@ Must be one of:
 
 | Property                                                 | Pattern | Type   | Deprecated | Definition | Title/Description                                                                                    |
 |----------------------------------------------------------|---------|--------|------------|------------|------------------------------------------------------------------------------------------------------|
-| - [user](#stages_items_actions_items_sudo_user )         | No      | string | No         | -          | Privileged user (default 'root')                                                                     |
+| - [user](#stages_items_actions_items_sudo_user )         | No      | string | No         | -          | Privileged user (default `root`)                                                                     |
 | - [password](#stages_items_actions_items_sudo_password ) | No      | string | No         | -          | Privileged password (empty by default). Can use `$env:` prefix to mark value as environment variable |
 
 ###### <a name="stages_items_actions_items_sudo_user"></a>1.1.2.1.8.1. Property `Autopilot Workflow Schema > stages > stages items > actions > actions items > sudo > user`
@@ -274,7 +274,7 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** Privileged user (default 'root')
+**Description:** Privileged user (default `root`)
 
 ###### <a name="stages_items_actions_items_sudo_password"></a>1.1.2.1.8.2. Property `Autopilot Workflow Schema > stages > stages items > actions > actions items > sudo > password`
 
@@ -314,7 +314,7 @@ Must be one of:
 | Property                                                   | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                    |
 |------------------------------------------------------------|---------|---------|------------|------------|------------------------------------------------------------------------------------------------------|
 | + [host](#stages_items_actions_items_remote_host )         | No      | string  | No         | -          | Remote SSH host                                                                                      |
-| - [port](#stages_items_actions_items_remote_port )         | No      | integer | No         | -          | Remote SSH port (default 22)                                                                         |
+| - [port](#stages_items_actions_items_remote_port )         | No      | integer | No         | -          | Remote SSH port (default `22`)                                                                       |
 | + [user](#stages_items_actions_items_remote_user )         | No      | string  | No         | -          | Remote SSH user                                                                                      |
 | - [password](#stages_items_actions_items_remote_password ) | No      | string  | No         | -          | Remote SSH password (empty by default). Can use `$env:` prefix to mark value as environment variable |
 
@@ -334,7 +334,7 @@ Must be one of:
 | **Type**     | `integer` |
 | **Required** | No        |
 
-**Description:** Remote SSH port (default 22)
+**Description:** Remote SSH port (default `22`)
 
 | Restrictions |            |
 |--------------|------------|
@@ -399,4 +399,4 @@ Must be one of:
 | **Minimum**  | &ge; 0 |
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2025-03-20 at 18:21:07 +0200
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2025-05-12 at 23:42:15 +0300

--- a/docs/config.md
+++ b/docs/config.md
@@ -264,7 +264,7 @@ Must be one of:
 
 | Property                                                 | Pattern | Type   | Deprecated | Definition | Title/Description                                                                                    |
 |----------------------------------------------------------|---------|--------|------------|------------|------------------------------------------------------------------------------------------------------|
-| - [user](#stages_items_actions_items_sudo_user )         | No      | string | No         | -          | Privileged user (default `root`)                                                                     |
+| - [user](#stages_items_actions_items_sudo_user )         | No      | string | No         | -          | Privileged user (default `root`). Can use `$env:` prefix to mark value as environment variable       |
 | - [password](#stages_items_actions_items_sudo_password ) | No      | string | No         | -          | Privileged password (empty by default). Can use `$env:` prefix to mark value as environment variable |
 
 ###### <a name="stages_items_actions_items_sudo_user"></a>1.1.2.1.8.1. Property `Autopilot Workflow Schema > stages > stages items > actions > actions items > sudo > user`
@@ -274,7 +274,7 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | No       |
 
-**Description:** Privileged user (default `root`)
+**Description:** Privileged user (default `root`). Can use `$env:` prefix to mark value as environment variable
 
 ###### <a name="stages_items_actions_items_sudo_password"></a>1.1.2.1.8.2. Property `Autopilot Workflow Schema > stages > stages items > actions > actions items > sudo > password`
 
@@ -311,11 +311,11 @@ Must be one of:
 | **Required**              | No          |
 | **Additional properties** | Not allowed |
 
-| Property                                                   | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                    |
-|------------------------------------------------------------|---------|---------|------------|------------|------------------------------------------------------------------------------------------------------|
-| + [host](#stages_items_actions_items_remote_host )         | No      | string  | No         | -          | Remote SSH host                                                                                      |
-| - [port](#stages_items_actions_items_remote_port )         | No      | integer | No         | -          | Remote SSH port (default `22`)                                                                       |
-| + [user](#stages_items_actions_items_remote_user )         | No      | string  | No         | -          | Remote SSH user                                                                                      |
+| Property                                                   | Pattern | Type    | Deprecated | Definition | Title/Description                                                                                           |
+|------------------------------------------------------------|---------|---------|------------|------------|-------------------------------------------------------------------------------------------------------------|
+| + [host](#stages_items_actions_items_remote_host )         | No      | string  | No         | -          | Remote SSH host. Can use `$env:` prefix to mark value as environment variable                               |
+| - [port](#stages_items_actions_items_remote_port )         | No      | integer | No         | -          | Remote SSH port (default `22`)                                                                              |
+| + [user](#stages_items_actions_items_remote_user )         | No      | string  | No         | -          | Remote SSH user. Can use `$env:` prefix to mark value as environment variable                               |
 | - [password](#stages_items_actions_items_remote_password ) | No      | string  | No         | -          | Remote SSH password (empty by default). Can use `$env:` prefix to mark value as environment variable |
 
 ###### <a name="stages_items_actions_items_remote_host"></a>1.1.2.1.11.1. Property `Autopilot Workflow Schema > stages > stages items > actions > actions items > remote > host`
@@ -325,7 +325,7 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | Yes      |
 
-**Description:** Remote SSH host
+**Description:** Remote SSH host. Can use `$env:` prefix to mark value as environment variable
 
 ###### <a name="stages_items_actions_items_remote_port"></a>1.1.2.1.11.2. Property `Autopilot Workflow Schema > stages > stages items > actions > actions items > remote > port`
 
@@ -348,7 +348,7 @@ Must be one of:
 | **Type**     | `string` |
 | **Required** | Yes      |
 
-**Description:** Remote SSH user
+**Description:** Remote SSH user. Can use `$env:` prefix to mark value as environment variable
 
 ###### <a name="stages_items_actions_items_remote_password"></a>1.1.2.1.11.4. Property `Autopilot Workflow Schema > stages > stages items > actions > actions items > remote > password`
 
@@ -399,4 +399,4 @@ Must be one of:
 | **Minimum**  | &ge; 0 |
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2025-05-12 at 23:42:15 +0300
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2025-05-14 at 23:33:57 +0300

--- a/src/app.rs
+++ b/src/app.rs
@@ -241,7 +241,7 @@ impl App {
         let exec_status = self.action_status.clone();
         *exec_status.lock().unwrap() = ActionStatus::Running;
 
-        let mut command_session = match CommandSession::new(remote, sudo) {
+        let mut command_session = match CommandSession::new(&command, remote, sudo) {
             Ok(command_session) => command_session,
             Err(e) => {
                 self.write_buf(
@@ -257,10 +257,7 @@ impl App {
             }
         };
 
-        let prompt = command_session.get_prompt()?;
-
-        let cmd = command.get_command();
-        self.write_buf(format!("{} {}\n", prompt, cmd), style);
+        self.write_buf(command_session.get_prompt()?, style);
 
         let buffer = self.buffer.clone();
         thread::spawn(move || {
@@ -272,7 +269,7 @@ impl App {
                     break;
                 }
 
-                command_session.run_command(cmd.clone()).unwrap();
+                command_session.run_command().unwrap();
                 Self::add_to_buf(buffer.clone(),
                                  &command_session.get_stdout(),
                                  hide_stdout);

--- a/src/app.rs
+++ b/src/app.rs
@@ -248,7 +248,7 @@ impl App {
                     format!(
                         "Failed to initialize a new session for command '{}' error: {}",
                         command.get_command(),
-                        e
+                        e,
                     ),
                     Some(StyleConfig::error()),
                 );

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@
 
 use crate::config::{self, CommandType, LoopConfig, RemoteConfig, StyleConfig, SudoConfig};
 use crate::session::CommandSession;
+use anyhow::Result;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     style::{Color, Style, Styled},
@@ -11,7 +12,6 @@ use ratatui::{
 };
 use std::{
     error,
-    io::self,
     sync::{Arc, Mutex},
     thread,
     time::Duration,
@@ -108,7 +108,7 @@ impl App {
     }
 
     /// updates the application's state based on user input
-    pub fn handle_events(&mut self, key_event: KeyEvent) -> io::Result<()> {
+    pub fn handle_events(&mut self, key_event: KeyEvent) -> Result<()> {
         Ok(match key_event.code {
             KeyCode::Char('q') | KeyCode::Char('Q') => self.exit(),
             KeyCode::Left => self.prev_action(),
@@ -168,7 +168,7 @@ impl App {
         self.buffer.lock().unwrap().pop();
     }
 
-    fn next_action(&mut self) -> io::Result<()> {
+    fn next_action(&mut self) -> Result<()> {
         if *self.action_status.lock().unwrap() == ActionStatus::Running {
             *self.action_status.lock().unwrap() = ActionStatus::Forced;
             return Ok(());
@@ -237,7 +237,7 @@ impl App {
         hide_stderr: bool,
         style: Option<StyleConfig>,
         loop_config: LoopConfig,
-    ) -> io::Result<()> {
+    ) -> Result<()> {
         let exec_status = self.action_status.clone();
         *exec_status.lock().unwrap() = ActionStatus::Running;
 
@@ -246,7 +246,7 @@ impl App {
             Err(e) => {
                 self.write_buf(
                     format!(
-                        "Failed to initialize a new session for command '{}' error: {}",
+                        "Failed to initialize a new session.\n\tCommand: {}\n\tError:   {}",
                         command.get_command(),
                         e,
                     ),

--- a/src/session.rs
+++ b/src/session.rs
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use crate::config::{RemoteConfig, SudoConfig};
-use anyhow::Context;
+use anyhow::{ensure, Context, Result};
 use ssh2::Session;
 use std::borrow::Cow;
 use std::{
     env,
-    io::{self, Error, ErrorKind, Read},
+    io::Read,
     net::TcpStream,
     process::Command,
 };
@@ -26,7 +26,7 @@ impl SessionConfiguration {
         }
     }
 
-    fn get_host(&self) -> io::Result<String> {
+    fn get_host(&self) -> Result<String> {
         match self {
             SessionConfiguration::Local() => Ok(whoami::fallible::hostname()?),
             SessionConfiguration::Remote(_, remote_config) => {
@@ -44,7 +44,7 @@ pub struct CommandSession {
 }
 
 impl CommandSession {
-    pub(crate) fn new(remote: Option<RemoteConfig>, sudo: Option<SudoConfig>) -> io::Result<Self> {
+    pub(crate) fn new(remote: Option<RemoteConfig>, sudo: Option<SudoConfig>) -> Result<Self> {
         Ok(
             Self {
                 session_configuration: if let Some(remote_config) = remote {
@@ -59,7 +59,7 @@ impl CommandSession {
         )
     }
 
-    pub(crate) fn get_prompt(&self) -> io::Result<String> {
+    pub(crate) fn get_prompt(&self) -> Result<String> {
         let (user, prompt_char)  = if let Some(sudo_config) = &self.sudo {
             (sudo_config.user.as_ref().unwrap(), '#')
         } else {
@@ -84,7 +84,7 @@ impl CommandSession {
         String::from_utf8_lossy(&self.stderr)
     }
 
-    pub(crate) fn run_command(&mut self, cmd: String) -> io::Result<()> {
+    pub(crate) fn run_command(&mut self, cmd: String) -> Result<()> {
         let cmd = self.get_sudo_command(cmd);
         (self.stdout, self.stderr) = match &self.session_configuration {
             SessionConfiguration::Local() => {
@@ -97,38 +97,33 @@ impl CommandSession {
 
         Ok(())
     }
+    
 
-    fn run_local_command(shell: &str, cmd: String) -> io::Result<(Vec<u8>, Vec<u8>)> {
+    fn run_local_command(shell: &str, cmd: String) -> Result<(Vec<u8>, Vec<u8>)> {
         let output = Command::new(shell)
             .arg("-c")
             .arg(cmd)
             .output()
-            .context("Failed to execute command")
-            // TODO: improve error handling
-            .unwrap();
+            .context("Failed to execute a local command")?;
 
         Ok((output.stdout, output.stderr))
     }
 
-    fn init_remote_session(remote_config: RemoteConfig) -> io::Result<SessionConfiguration> {
+    fn init_remote_session(remote_config: RemoteConfig) -> Result<SessionConfiguration> {
         let addr = format!("{}:{}", remote_config.host, remote_config.port.unwrap());
         let tcp = TcpStream::connect(addr)?;
         let mut session = Session::new()?;
         session.set_tcp_stream(tcp);
         session.handshake()?;
 
-        // TODO: improve error handling
-        let password = Self::resolve_env(remote_config.password.as_ref()).unwrap();
+        let password = Self::resolve_env(remote_config.password.as_ref())?;
         session.userauth_password(&remote_config.user, &password)?;
-
-        if !session.authenticated() {
-            return Err(Error::from(ErrorKind::ConnectionRefused));
-        }
+        ensure!(session.authenticated(), "Session password authentication failed");
 
         Ok(SessionConfiguration::Remote(session, remote_config))
     }
 
-    fn run_remote_command(session: &Session, cmd: String) -> io::Result<(Vec<u8>, Vec<u8>)> {
+    fn run_remote_command(session: &Session, cmd: String) -> Result<(Vec<u8>, Vec<u8>)> {
         let mut channel = session.channel_session()?;
         channel.exec(cmd.as_str())?;
 
@@ -141,11 +136,11 @@ impl CommandSession {
         Ok((stdout, stderr))
     }
 
-    fn resolve_env(password: Option<&String>) -> anyhow::Result<String> {
+    fn resolve_env(password: Option<&String>) -> Result<String> {
         let value = password.unwrap();
         if value.starts_with("$env:") {
             let env_var = &value[5..];
-            env::var(env_var).with_context(|| format!("Missing environment variable: {}", env_var))
+            env::var(env_var).with_context(|| format!("Missing environment variable: '{}'", env_var))
         } else {
             Ok(value.to_string())
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -48,11 +48,13 @@ impl CommandSession {
         Ok(
             Self {
                 session_configuration: if let Some(remote_config) = remote {
-                    Self::init_remote_session(remote_config)?
+                    Self::init_remote_session(Self::resolve_remote_config(remote_config)?)?
                 } else {
                     SessionConfiguration::Local()
                 },
-                sudo,
+                sudo: sudo
+                    .map(|sudo_config| Self::resolve_sudo_config(sudo_config))
+                    .transpose()?,
                 stdout: Vec::new(),
                 stderr: Vec::new(),
             }
@@ -97,7 +99,6 @@ impl CommandSession {
 
         Ok(())
     }
-    
 
     fn run_local_command(shell: &str, cmd: String) -> Result<(Vec<u8>, Vec<u8>)> {
         let output = Command::new(shell)
@@ -109,6 +110,26 @@ impl CommandSession {
         Ok((output.stdout, output.stderr))
     }
 
+    fn resolve_remote_config(remote_config: RemoteConfig) -> Result<RemoteConfig> {
+        Ok(
+            RemoteConfig {
+                host: remote_config.host,
+                port: remote_config.port,
+                user: remote_config.user,
+                password: Self::resolve_env_opt(remote_config.password)?,
+            }
+        )
+    }
+
+    fn resolve_sudo_config(sudo_config: SudoConfig) -> Result<SudoConfig> {
+        Ok(
+            SudoConfig {
+                user: sudo_config.user,
+                password: Self::resolve_env_opt(sudo_config.password)?,
+            }
+        )
+    }
+
     fn init_remote_session(remote_config: RemoteConfig) -> Result<SessionConfiguration> {
         let addr = format!("{}:{}", remote_config.host, remote_config.port.unwrap());
         let tcp = TcpStream::connect(addr)?;
@@ -116,8 +137,7 @@ impl CommandSession {
         session.set_tcp_stream(tcp);
         session.handshake()?;
 
-        let password = Self::resolve_env(remote_config.password.as_ref())?;
-        session.userauth_password(&remote_config.user, &password)?;
+        session.userauth_password(&remote_config.user, remote_config.password.as_ref().unwrap())?;
         ensure!(session.authenticated(), "Session password authentication failed");
 
         Ok(SessionConfiguration::Remote(session, remote_config))
@@ -136,21 +156,29 @@ impl CommandSession {
         Ok((stdout, stderr))
     }
 
-    fn resolve_env(password: Option<&String>) -> Result<String> {
-        let value = password.unwrap();
+    fn resolve_env_str(value: String) -> Result<String> {
         if value.starts_with("$env:") {
             let env_var = &value[5..];
             env::var(env_var).with_context(|| format!("Missing environment variable: '{}'", env_var))
         } else {
-            Ok(value.to_string())
+            Ok(value)
         }
+    }
+
+    fn resolve_env_opt(value_opt: Option<String>) -> Result<Option<String>> {
+        value_opt
+            .map(|value| Self::resolve_env_str(value))
+            .transpose()
     }
 
     fn get_sudo_command(&self, cmd: String) -> String {
         if let Some(sudo_config) = &self.sudo {
-            let user = sudo_config.user.as_ref().unwrap();
-            let password = Self::resolve_env(sudo_config.password.as_ref()).unwrap();
-            format!("echo {} | sudo -kS -u {} -p '' {}", password, user, cmd)
+            format!(
+                "echo {} | sudo -kS -u {} -p '' {}",
+                sudo_config.password.as_ref().unwrap(),
+                sudo_config.user.as_ref().unwrap(),
+                cmd,
+            )
         } else {
             cmd
         }

--- a/src/session.rs
+++ b/src/session.rs
@@ -5,15 +5,14 @@
 use crate::config::{RemoteConfig, SudoConfig};
 use anyhow::Context;
 use ssh2::Session;
+use std::borrow::Cow;
 use std::{
     env,
-    io::{self, Read, Error, ErrorKind},
+    io::{self, Error, ErrorKind, Read},
     net::TcpStream,
     process::Command,
 };
-use std::borrow::Cow;
 
-#[derive(Clone)]
 enum SessionConfiguration {
     Local(),
     Remote(Session, RemoteConfig),
@@ -35,20 +34,6 @@ impl SessionConfiguration {
             },
         }
     }
-
-    fn run_command(&mut self, cmd: String) -> io::Result<(Vec<u8>, Vec<u8>)> {
-        match self {
-            SessionConfiguration::Local() => {
-                CommandSession::run_local_command("sh", cmd)
-            }
-            SessionConfiguration::Remote(session, _) => {
-                CommandSession::run_remote_command(
-                    &session,
-                    cmd,
-                )
-            }
-        }
-    }
 }
 
 pub struct CommandSession {
@@ -63,7 +48,7 @@ impl CommandSession {
         Ok(
             Self {
                 session_configuration: if let Some(remote_config) = remote {
-                    SessionConfiguration::Remote(Self::init_remote_session(&remote_config)?, remote_config)
+                    Self::init_remote_session(remote_config)?
                 } else {
                     SessionConfiguration::Local()
                 },
@@ -81,7 +66,14 @@ impl CommandSession {
             (&self.session_configuration.get_effective_user(), '$')
         };
 
-        Ok(format!("[{}@{}]{}", user, self.session_configuration.get_host()?, prompt_char))
+        Ok(
+            format!(
+                "[{}@{}]{}",
+                user,
+                self.session_configuration.get_host()?,
+                prompt_char,
+            )
+        )
     }
 
     pub(crate) fn get_stdout(&self) -> Cow<'_, str> {
@@ -93,7 +85,16 @@ impl CommandSession {
     }
 
     pub(crate) fn run_command(&mut self, cmd: String) -> io::Result<()> {
-        (self.stdout, self.stderr) = self.session_configuration.run_command(self.get_sudo_command(cmd))?;
+        let cmd = self.get_sudo_command(cmd);
+        (self.stdout, self.stderr) = match &self.session_configuration {
+            SessionConfiguration::Local() => {
+                Self::run_local_command("sh", cmd)?
+            }
+            SessionConfiguration::Remote(session, _) => {
+                Self::run_remote_command(session, cmd)?
+            }
+        };
+
         Ok(())
     }
 
@@ -109,7 +110,7 @@ impl CommandSession {
         Ok((output.stdout, output.stderr))
     }
 
-    fn init_remote_session(remote_config: &RemoteConfig) -> io::Result<Session> {
+    fn init_remote_session(remote_config: RemoteConfig) -> io::Result<SessionConfiguration> {
         let addr = format!("{}:{}", remote_config.host, remote_config.port.unwrap());
         let tcp = TcpStream::connect(addr)?;
         let mut session = Session::new()?;
@@ -124,7 +125,7 @@ impl CommandSession {
             return Err(Error::from(ErrorKind::ConnectionRefused));
         }
 
-        Ok(session)
+        Ok(SessionConfiguration::Remote(session, remote_config))
     }
 
     fn run_remote_command(session: &Session, cmd: String) -> io::Result<(Vec<u8>, Vec<u8>)> {

--- a/src/session.rs
+++ b/src/session.rs
@@ -113,9 +113,9 @@ impl CommandSession {
     fn resolve_remote_config(remote_config: RemoteConfig) -> Result<RemoteConfig> {
         Ok(
             RemoteConfig {
-                host: remote_config.host,
+                host: Self::resolve_env_str(remote_config.host)?,
                 port: remote_config.port,
-                user: remote_config.user,
+                user: Self::resolve_env_str(remote_config.user)?,
                 password: Self::resolve_env_opt(remote_config.password)?,
             }
         )
@@ -124,7 +124,7 @@ impl CommandSession {
     fn resolve_sudo_config(sudo_config: SudoConfig) -> Result<SudoConfig> {
         Ok(
             SudoConfig {
-                user: sudo_config.user,
+                user: Self::resolve_env_opt(sudo_config.user)?,
                 password: Self::resolve_env_opt(sudo_config.password)?,
             }
         )


### PR DESCRIPTION
Multiple enhancements:
* Environment variables' support:
Previously only passwords (for `ssh` connections and `sudo`) were configurable via environment variables.
Now additional configurations can be done this way, which will make it easier to run the same flows on another host.
The following fields now support environment variables:
  * Remote (`ssh`) host.
  * Remote (`ssh`) user.
  * Privileged (`sudo`) user.
  * Inside commands, like `command: config_collector.sh $env:GRAFANA_IP`.
* Improved error handling:
  * Using `crate anyhow` to improve error handling and propagate errors upwards.
  * In particular, missing environment variable(s) now doesn't crash the tool with an ugly output, but print an error and continue to the next command.
* Code refactoring, schema and documentation improvements.

Signed-off-by: Pavel Bar <pbar@redhat.com>
